### PR TITLE
 xposed hooked methods should be excluded in more places, like native & runtime

### DIFF
--- a/runtime/thread.cc
+++ b/runtime/thread.cc
@@ -2768,7 +2768,7 @@ class ReferenceMapVisitor : public StackVisitor {
     VisitDeclaringClass(m);
 
     // Process register map (which native and runtime methods don't have)
-    if (!m->IsNative() && !m->IsRuntimeMethod() && (!m->IsProxyMethod() || m->IsConstructor())) {
+    if (!m->IsNative() && !m->IsRuntimeMethod() && !m->IsXposedHookedMethod() && (!m->IsProxyMethod() || m->IsConstructor())) {
       const OatQuickMethodHeader* method_header = GetCurrentOatQuickMethodHeader();
       DCHECK(method_header->IsOptimized());
       auto* vreg_base = reinterpret_cast<StackReference<mirror::Object>*>(


### PR DESCRIPTION
The Thread::VisitRoots function goes to the Thread::VisitQuickFrame function, and there are also native and Runtime methods that are excluded like in ArtMethod::VisitRoots therefore, xposed hooked methods should also be excluded.